### PR TITLE
Use stream-json library for efficient JSON parsing & streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "passport-local": "^1.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
-    "simdjson": "^0.9.2"
+    "simdjson": "^0.9.2",
+    "stream-json": "^1.8.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/companies/commands/handlers/import-companies.handler.spec.ts
+++ b/src/companies/commands/handlers/import-companies.handler.spec.ts
@@ -13,18 +13,22 @@ import { AbstractImportStrategy } from '@/companies/import-strategies/abstract-i
 
 @Injectable()
 class TestCompaniesImportStategy extends AbstractImportStrategy {
-  public supportsImport(json: FastJsonParser): boolean {
-    return json.getParsedValueFromKey('name') === 'test-file';
+  public async supportsImport(json: FastJsonParser): Promise<boolean> {
+    try {
+      return (await json.getParsedValueFromKey('name').next()).value === 'test-file'
+        && typeof (await json.getParsedValueFromKey('companyCount').next()).value === 'number';
+    } catch (error) {
+      return false;
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public getImportId(json: FastJsonParser): string {
+  public async getImportId(json: FastJsonParser): Promise<string> {
     return 'test-file-import';
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public *generateCompany(json: FastJsonParser): Generator<Company> {
-    const companyCount = json.getParsedValueFromKey<number>('companyCount');
+  public async *generateCompany(json: FastJsonParser): AsyncGenerator<Company> {
+    const companyCount = (await json.getParsedValueFromKey<number>('companyCount').next()).value;
     for (let i = 0; i < companyCount; i++) {
       yield new Company();
     }

--- a/src/companies/import-strategies/abstract-import.strategy.ts
+++ b/src/companies/import-strategies/abstract-import.strategy.ts
@@ -5,17 +5,17 @@ export abstract class AbstractImportStrategy {
   /**
    * Return true if the import file is supported else false
    */
-  public abstract supportsImport(json: FastJsonParser): boolean;
+  public abstract supportsImport(json: FastJsonParser): Promise<boolean>;
 
   /**
    * Returns the identifier of the imported file
    */
-  public abstract getImportId(json: FastJsonParser): string;
+  public abstract getImportId(json: FastJsonParser): Promise<string>;
 
   /**
    * A generator function that returns a Company entity from the imported JSON file
    */
   public abstract generateCompany(
     json: FastJsonParser,
-  ): Generator<Company> | AsyncGenerator<Company>;
+  ): AsyncGenerator<Company>;
 }

--- a/src/companies/import-strategies/french-companies-import.strategy.spec.ts
+++ b/src/companies/import-strategies/french-companies-import.strategy.spec.ts
@@ -62,17 +62,17 @@ describe('FrenchCompaniesImportStrategy', () => {
 
   describe('supportsImport', () => {
     it('returns true when the GeoJSON is fully supported', async () => {
-      const jsonParser = new FastJsonParser(JSON.stringify(validGeoJson));
+      const jsonParser = new FastJsonParser(Buffer.from(JSON.stringify(validGeoJson)));
 
-      const result = strategy.supportsImport(jsonParser);
+      const result = await strategy.supportsImport(jsonParser);
 
       expect(result).toStrictEqual(true);
     });
 
     it('returns false when the JSON file does not contain the properties needed', async () => {
-      const jsonParser = new FastJsonParser('{}');
+      const jsonParser = new FastJsonParser(Buffer.from('{}'));
 
-      const result = strategy.supportsImport(jsonParser);
+      const result = await strategy.supportsImport(jsonParser);
 
       expect(result).toStrictEqual(false);
     });
@@ -81,9 +81,9 @@ describe('FrenchCompaniesImportStrategy', () => {
       const invalidGeoJson = {
         type: 'SomeOtherType',
       };
-      const jsonParser = new FastJsonParser(JSON.stringify(invalidGeoJson));
+      const jsonParser = new FastJsonParser(Buffer.from(JSON.stringify(invalidGeoJson)));
 
-      const result = strategy.supportsImport(jsonParser);
+      const result = await strategy.supportsImport(jsonParser);
 
       expect(result).toStrictEqual(false);
     });
@@ -98,9 +98,9 @@ describe('FrenchCompaniesImportStrategy', () => {
           },
         },
       };
-      const jsonParser = new FastJsonParser(JSON.stringify(invalidGeoJson));
+      const jsonParser = new FastJsonParser(Buffer.from(JSON.stringify(invalidGeoJson)));
 
-      const result = strategy.supportsImport(jsonParser);
+      const result = await strategy.supportsImport(jsonParser);
 
       expect(result).toStrictEqual(false);
     });
@@ -124,30 +124,30 @@ describe('FrenchCompaniesImportStrategy', () => {
           },
         ],
       };
-      const jsonParser = new FastJsonParser(JSON.stringify(invalidGeoJson));
+      const jsonParser = new FastJsonParser(Buffer.from(JSON.stringify(invalidGeoJson)));
 
-      const result = strategy.supportsImport(jsonParser);
+      const result = await strategy.supportsImport(jsonParser);
 
       expect(result).toStrictEqual(false);
     });
   });
 
   describe('getImportId', () => {
-    it('returns the value of "name" property in the GeoJSON', () => {
-      const jsonParser = new FastJsonParser(JSON.stringify(validGeoJson));
+    it('returns the value of "name" property in the GeoJSON', async () => {
+      const jsonParser = new FastJsonParser(Buffer.from(JSON.stringify(validGeoJson)));
 
-      const result = strategy.getImportId(jsonParser);
+      const result = await strategy.getImportId(jsonParser);
 
       expect(result).toEqual('some-businesses');
     });
 
-    it('throws an error when the property "name" does not exist', () => {
+    it('throws an error when the property "name" does not exist', async () => {
       const invalidGeoJson = {
         type: 'FeatureCollection',
       };
-      const jsonParser = new FastJsonParser(JSON.stringify(invalidGeoJson));
+      const jsonParser = new FastJsonParser(Buffer.from(JSON.stringify(invalidGeoJson)));
 
-      expect(() => strategy.getImportId(jsonParser)).toThrow(
+      expect(strategy.getImportId(jsonParser)).rejects.toThrow(
         InvalidArgumentException,
       );
     });
@@ -155,7 +155,7 @@ describe('FrenchCompaniesImportStrategy', () => {
 
   describe('generateCompany', () => {
     it('returns an async generator that yield 2 companies', async () => {
-      const jsonParser = new FastJsonParser(JSON.stringify(validGeoJson));
+      const jsonParser = new FastJsonParser(Buffer.from(JSON.stringify(validGeoJson)));
       queryBusMock.execute.mockResolvedValue({
         '72.20Z': 'Recherche-développement en sciences humaines et sociales',
         '47.71Z': "Commerce de détail d'habillement en magasin spécialisé",
@@ -188,7 +188,7 @@ describe('FrenchCompaniesImportStrategy', () => {
       const invalidGeoJson = {
         type: 'FeatureCollection',
       };
-      const jsonParser = new FastJsonParser(JSON.stringify(invalidGeoJson));
+      const jsonParser = new FastJsonParser(Buffer.from(JSON.stringify(invalidGeoJson)));
 
       const generator = strategy.generateCompany(jsonParser);
 

--- a/src/shared/helpers/fast-json.parser.ts
+++ b/src/shared/helpers/fast-json.parser.ts
@@ -1,24 +1,41 @@
-import * as simdjson from 'simdjson';
+import { Readable } from 'stream'
+import { chain } from 'stream-chain';
+import { verifier } from 'stream-json/utils/Verifier';
+import * as Pick from 'stream-json/filters/Pick';
+import { streamArray } from 'stream-json/streamers/StreamArray';
+import { streamValues } from 'stream-json/streamers/StreamValues';
 import { InvalidArgumentException } from '@/shared/exceptions/invalid-argument.exception';
 
 /**
  * This class is a facade of the library used to parse big JSON file efficiently
  */
 export class FastJsonParser {
-  private jsonBuffer: simdjson.JSONTape;
+  constructor(private readonly jsonBuffer: Buffer) {}
 
-  constructor(json: string) {
-    this.jsonBuffer = simdjson.lazyParse(json);
+  public async isValid(): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const pipeline = chain([
+        Readable.from(this.jsonBuffer),
+        verifier()
+      ]);
+      pipeline
+        .on('error', () => resolve(false))
+        .on('end', () => resolve(true));
+    });
   }
 
-  public static isValid(json: string): boolean {
-    return simdjson.isValid(json);
-  }
-
-  public getParsedValueFromKey<T>(key: string): T {
-    try {
-      return this.jsonBuffer.valueForKeyPath(key);
-    } catch (error) {
+  public async *getParsedValueFromKey<T>(key: string, options: { isArray?: boolean } = {}): AsyncGenerator<T> {
+    const pipeline = chain([
+      Readable.from(this.jsonBuffer),
+      Pick.withParser({filter: key}),
+      options?.isArray ? streamArray() : streamValues()
+    ]);
+    let foundData = 0;
+    for await (const data of pipeline) {
+      foundData++;
+      yield data.value;
+    }
+    if (foundData === 0) {
       throw new InvalidArgumentException(
         `Could not find the following JSON field: ${key}`,
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8127,6 +8127,18 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
+stream-chain@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.2.5.tgz#b30967e8f14ee033c5b9a19bbe8a2cba90ba0d09"
+  integrity sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==
+
+stream-json@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.8.0.tgz#53f486b2e3b4496c506131f8d7260ba42def151c"
+  integrity sha512-HZfXngYHUAr1exT4fxlbc1IOce1RYxp2ldeaf97LYCOPSoOqY/1Psp7iGvpb+6JIOgkra9zDYnPX01hGAHzEPw==
+  dependencies:
+    stream-chain "^2.2.5"
+
 streamsearch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"


### PR DESCRIPTION
On very big GeoJSON files, parsing is very slow and memory footprint is important after parsing.

A good solution is to use the [stream-json](https://www.npmjs.com/package/stream-json) library to parse and stream small parts of the big GeoJSON file.

For now, this is in work in progress because I identified that the `simdjson` library is faster than stream-json for files of ~20Mb.
It means it may be interesting to implement an adaptable solution where the right parsing solution is used depending on the size of the data.
